### PR TITLE
Fix default Tk font specification causing launch error

### DIFF
--- a/flyback_tool_v12_final/flyback_gui_v12.py
+++ b/flyback_tool_v12_final/flyback_gui_v12.py
@@ -69,7 +69,7 @@ class App(tk.Tk):
         style.configure("Accent.TButton", padding=6, foreground="white", background="#0078D7")
         style.map("Accent.TButton", background=[('active', '#005A9E')])
         style.configure("Treeview.Heading", font=("Segoe UI", 10, "bold"))
-        self.option_add("*Font", "Segoe UI 10")
+        self.option_add("*Font", "{Segoe UI} 10")
         nb = ttk.Notebook(self); nb.pack(fill="both", expand=True)
         self.nb = nb
         self.model: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
- fix Tkinter default font to handle spaces in family name

## Testing
- `python -m py_compile flyback_tool_v12_final/flyback_gui_v12.py`
- `python flyback_tool_v12_final/flyback_gui_v12.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68908c069310832f921069d9adb3a13f