### PR TITLE
Refine wire sizing and per-output VRRM

### DIFF
--- a/flyback_tool_v12_final/flyback_design_v12.py
+++ b/flyback_tool_v12_final/flyback_design_v12.py
@@ -41,34 +41,47 @@ AWG_TABLE = [
     (39, 0.00632), (40, 0.0050)
 ]
 
-def select_awg(area_req: float) -> Dict[str, float]:
-    """Pick AWG size and number of parallels so total area ≥ area_req, strands ≤5.
+def select_awg(area_req: float, delta_mm: Optional[float] = None) -> Dict[str, float]:
+    """Pick an AWG size and number of parallels so total area ≥ area_req.
 
-    The previous implementation minimised only the excess copper area and could
-    prefer many thin wires when their combined area happened to match the
-    requirement.  In practice, winding with several parallel wires complicates
-    manufacturing, especially for high turn counts.  This version first
-    minimises the number of parallel strands and only then the total copper
-    area, yielding more practical single‑wire solutions when possible.
+    If ``delta_mm`` is provided, only gauges whose diameter does not exceed
+    ``2*delta_mm`` are considered first, thus favouring thinner strands that
+    reduce skin‑effect losses.  The search always restricts the number of
+    parallel wires to at most five; if no suitable combination is found within
+    the skin‑depth limit, the full table is searched as a fall‑back.
     """
 
-    best = None  # (gauge, area, n, total, excess)
-    for gauge, area in AWG_TABLE:
-        n = max(1, math.ceil(area_req / area))
-        if n > 5:
-            continue
-        total = n * area
-        excess = total - area_req
-        if best is None or (n < best[2]) or (n == best[2] and total < best[3]):
-            best = (gauge, area, n, total, excess)
+    def eval_table(table):
+        best = None  # (gauge, area, n, total)
+        for gauge, area in table:
+            n = max(1, math.ceil(area_req / area))
+            if n > 5:
+                continue
+            total = n * area
+            if best is None or (n < best[2]) or (n == best[2] and total < best[3]):
+                best = (gauge, area, n, total)
+        return best
+
+    table = AWG_TABLE
+    if delta_mm is not None:
+        limit = 2.0 * delta_mm
+        table = [
+            (g, a) for g, a in AWG_TABLE
+            if math.sqrt(4.0 * a / math.pi) <= limit
+        ]
+        best = eval_table(table)
+        if best is None:
+            best = eval_table(AWG_TABLE)
+    else:
+        best = eval_table(AWG_TABLE)
 
     if best is None:
         gauge, area = AWG_TABLE[-1]
         n = min(5, math.ceil(area_req / area))
         total = n * area
-        best = (gauge, area, n, total, total - area_req)
+        best = (gauge, area, n, total)
 
-    gauge, area, n, total, _ = best
+    gauge, area, n, total = best
     return {"awg": f"AWG{gauge}", "awg_area_mm2": area, "parallel": n, "total_area_mm2": total}
 
 @dataclass
@@ -220,7 +233,7 @@ def estimate_initial_design(fin: FlybackInput, outputs: List[OutputSpec], cin_vr
     diode_vrrm_each, cout_each, per_out = {}, {}, {}
     for o in outputs:
         k_i = vref / (o.v + o.diode_drop)
-        diode_vrrm_each[o.name] = k_i * fin.vin_max + o.v + o.diode_drop
+        diode_vrrm_each[o.name] = fin.vin_max / k_i + o.v
         # Cout ≈ Iout*(1-D)/(2*ΔV*f_sw) for DCM flyback
         cout_each[o.name] = (o.i * (1.0 - dmin)) / (2.0 * max(1e-6, o.ripple_v) * fin.fsw)
         per_out[o.name] = {"k_np_over_ns_ideal": k_i, "cout_min_F": cout_each[o.name], "diode_vrrm_ideal_V": diode_vrrm_each[o.name]}
@@ -282,8 +295,8 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
     # Wires with AWG selection
     delta = skin_depth_mm(fin.fsw)
     wires: Dict[str, Dict[str,float]] = {}
-    area_pri = irms_pri / geom.jmax_A_per_mm2
-    sel_pri = select_awg(area_pri)
+    area_pri = irms_pri * fin.overload * geom.ac_factor_pri / geom.jmax_A_per_mm2
+    sel_pri = select_awg(area_pri, delta)
     wires["primary_area_mm2"] = area_pri
     wires["primary_awg"] = sel_pri["awg"]
     wires["primary_awg_area_mm2"] = sel_pri["awg_area_mm2"]
@@ -295,10 +308,13 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
     for o in outputs:
         k_i = np_turns / ns_turns[o.name]
         ipk_sec = ipk * k_i
-        irms_sec = ipk_sec * ((1.0 - ini.d_vin_min)/3.0) ** 0.5
+        toff_i = min((2.0 * o.i * period) / max(1e-12, ipk_sec),
+                      (1.0 - ini.d_vin_min) * period)
+        duty_i = toff_i / period
+        irms_sec = ipk_sec * math.sqrt(duty_i/3.0)
         irms_sec_map[o.name] = irms_sec
-        area_sec = irms_sec / geom.jmax_A_per_mm2
-        sel = select_awg(area_sec)
+        area_sec = o.i * fin.overload * geom.ac_factor_sec / geom.jmax_A_per_mm2
+        sel = select_awg(area_sec, delta)
         wires[f"{o.name}_area_mm2"] = area_sec
         wires[f"{o.name}_awg"] = sel["awg"]
         wires[f"{o.name}_awg_area_mm2"] = sel["awg_area_mm2"]
@@ -311,7 +327,7 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
     diode_vrrm_ideal_each, diode_vrrm_required_each = {}, {}
     for o in outputs:
         k_i = np_turns / ns_turns[o.name]
-        vrrm = k_i * fin.vin_max + o.v + o.diode_drop
+        vrrm = fin.vin_max / k_i + o.v
         diode_vrrm_ideal_each[o.name] = vrrm
         diode_vrrm_required_each[o.name] = vrrm * 1.15
 
@@ -386,7 +402,7 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
         Prr = 0.0
         if o.qrr_nC:
             k_i = np_turns / ns_turns[o.name]
-            Vrev = k_i * fin.vin_max
+            Vrev = fin.vin_max / k_i
             Prr = (o.qrr_nC * 1e-9) * Vrev * fin.fsw
         P_diodes[o.name] = {"Pcond_W": Pcond, "Prr_W": Prr}
     losses["Pdiodes"] = P_diodes
@@ -423,11 +439,15 @@ def sweep_k(fin: FlybackInput, outputs: List[OutputSpec], geom: Geometry, core: 
                                force_dcm=force_dcm)
         vds = ref.vds_with_overhead_V
         ipk = ref.ipk_new_A
-        vrrm_max = max(ref.diode_vrrm_required_each_V.values())
+        vrrm_each = ref.diode_vrrm_required_each_V
+        vrrm_max = max(vrrm_each.values())
         loss = ref.losses.get("Ptotal_W", float("inf"))
         metric = {"min_vds": vds, "min_ipk": ipk, "min_vrrm": vrrm_max, "min_loss": loss}.get(criterion, vds)
-        grid.append({"D": D, "Vref": vref, "K": ini.k_np_over_ns, "Vds": vds, "Ipk": ipk, "VRRM_max": vrrm_max, "Ploss": loss,
-                     "ini": asdict(ini), "ref": asdict(ref)})
+        row = {"D": D, "Vref": vref, "K": ini.k_np_over_ns, "Vds": vds, "Ipk": ipk, "Ploss": loss, "VRRM_max": vrrm_max,
+               "ini": asdict(ini), "ref": asdict(ref)}
+        for name, v in vrrm_each.items():
+            row[f"VRRM_{name}"] = v
+        grid.append(row)
         if best is None or metric < best["metric"]:
             best = {"metric": metric, "D": D, "ini": ini, "ref": ref}
     return {"criterion": criterion, "best": best, "grid": grid}

--- a/flyback_tool_v12_final/flyback_gui_v12.py
+++ b/flyback_tool_v12_final/flyback_gui_v12.py
@@ -371,9 +371,17 @@ class App(tk.Tk):
                              force_dcm=fin.force_dcm)
             lines = []
             lines.append(f"Criterion: {crit}")
-            lines.append("D     Vref[V]   K_ideal  Vds[V]   Ipk[A]  VRRM_max[V]  Ploss[W]")
+            header = ["D", "Vref[V]", "K_ideal", "Vds[V]", "Ipk[A]"]
+            for o in outs:
+                header.append(f"VRRM_{o.name}[V]")
+            header.append("Ploss[W]")
+            lines.append("  ".join(header))
             for row in sweep["grid"]:
-                lines.append(f"{row['D']:.3f}  {row['Vref']:.1f}  {row['K']:.3f}   {row['Vds']:.1f}   {row['Ipk']:.2f}   {row['VRRM_max']:.1f}     {row['Ploss']:.2f}")
+                line = f"{row['D']:.3f}  {row['Vref']:.1f}  {row['K']:.3f}   {row['Vds']:.1f}   {row['Ipk']:.2f}"
+                for o in outs:
+                    line += f"   {row[f'VRRM_{o.name}']:.1f}"
+                line += f"     {row['Ploss']:.2f}"
+                lines.append(line)
             best = sweep["best"]
             lines.append("")
             lines.append(f"BEST: D={best['D']:.3f}")
@@ -433,13 +441,14 @@ class App(tk.Tk):
             lines.append(f"VDS ideal = {r['vds_ideal_V']:.2f} V")
             lines.append(f"VDS with clamp = {r['vds_with_overhead_V']:.2f} V")
             lines.append("")
-            vrrm_max = max(r['diode_vrrm_required_each_V'].values()) if r.get('diode_vrrm_required_each_V') else None
-            if vrrm_max is not None:
-                lines.append(f"VRRM_max(sec) = {vrrm_max:.2f} V")
+            if r.get('diode_vrrm_required_each_V'):
+                for name, v in r['diode_vrrm_required_each_V'].items():
+                    lines.append(f"VRRM[{name}] = {v:.2f} V")
             if r.get('rcd'):
                 rc = r['rcd']
                 lines.append(f"RCD clamp: Vclamp = {rc['Vclamp_V']:.1f} V; C = {rc['C_snub_F']:.3e} F; R = {rc['R_snub_Ohm']:.1f} Ω; P_snub = {rc['P_lk_W']:.2f} W")
             lines.append("--- ПРОВОДНИКИ ---")
+            lines.append(f"Skin depth ≈ {r['wires']['skin_depth_mm']:.3f} мм")
             lines.append(
                 f"A_cu_primary = {r['wires']['primary_area_mm2']:.6f} мм^2 -> {r['wires']['primary_awg']}"
                 f" ({r['wires']['primary_awg_area_mm2']:.3f} мм^2) x{int(r['wires']['primary_parallel'])}"


### PR DESCRIPTION
## Summary
- size secondary wires from load current with overload/AC factors and report skin depth
- compute secondary diode VRRM as Vin_max/K + Vout and show per-output in GUI & K-optimizer

## Testing
- `python flyback_design_v12.py --config design_article_example.json --json >/tmp/out.json`
- `rg "primary_total_area_mm2" -n /tmp/out.json`


------
https://chatgpt.com/codex/tasks/task_e_6890ab0aa368832fb93d708f63b46b3b