### PR TITLE
Display delta B and actual Vout

### DIFF
--- a/flyback_tool_v12_final/flyback_design_v12.py
+++ b/flyback_tool_v12_final/flyback_design_v12.py
@@ -194,6 +194,7 @@ class RefinedDesign:
     dcm_ok_main: bool
     t_off_main_s: float
     lsec_main_H: float
+    delta_B_T: float
     wires: Dict[str, Any]
     vds_ideal_V: float
     vds_with_overhead_V: float
@@ -291,6 +292,9 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
             break
         np_turns += 1
 
+    # Flux swing (ΔB)
+    dB = (fin.vin_max * ini.d_vin_min) / (np_turns * Ae * fin.fsw)
+
     # Wires with AWG selection
     delta = skin_depth_mm(fin.fsw)
     wires: Dict[str, Dict[str,float]] = {}
@@ -376,7 +380,6 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
 
     p_core_W = None
     if core.core_volume_mm3 and stein:
-        dB = (fin.vin_max * ini.d_vin_min) / (np_turns * Ae * fin.fsw)
         Pv = stein.k * (fin.fsw**stein.alpha) * (dB**stein.beta)
         vol_m3 = core.core_volume_mm3 * 1e-9
         p_core_W = Pv * vol_m3
@@ -419,7 +422,7 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
         np_turns=np_turns, ns_turns=ns_turns, k_actual_np_over_ns_main=k_act,
         gap_m=gap, lm_actual_H=lm_actual, ipk_new_A=ipk, irms_pri_new_A=irms_pri,
         dcm_ok_main=dcm_ok, t_off_main_s=toff, lsec_main_H=lsec_main,
-        wires=wires, vds_ideal_V=vds_ideal, vds_with_overhead_V=vds_required,
+        delta_B_T=dB, wires=wires, vds_ideal_V=vds_ideal, vds_with_overhead_V=vds_required,
         diode_vrrm_ideal_each_V=diode_vrrm_ideal_each, diode_vrrm_required_each_V=diode_vrrm_required_each,
         fill_factor=fill_factor, rcd=rcd_info, core_loss_W=p_core_W, losses=losses, notes=notes
     )
@@ -442,7 +445,8 @@ def sweep_k(fin: FlybackInput, outputs: List[OutputSpec], geom: Geometry, core: 
         vrrm_max = max(vrrm_each.values())
         loss = ref.losses.get("Ptotal_W", float("inf"))
         metric = {"min_vds": vds, "min_ipk": ipk, "min_vrrm": vrrm_max, "min_loss": loss}.get(criterion, vds)
-        row = {"D": D, "Vref": vref, "K": ini.k_np_over_ns, "Vds": vds, "Ipk": ipk, "Ploss": loss, "VRRM_max": vrrm_max,
+        row = {"D": D, "Vref": vref, "K": ini.k_np_over_ns, "Vds": vds, "Ipk": ipk,
+               "dB_T": ref.delta_B_T, "Ploss": loss, "VRRM_max": vrrm_max,
                "ini": asdict(ini), "ref": asdict(ref)}
         for name, v in vrrm_each.items():
             row[f"VRRM_{name}"] = v

--- a/flyback_tool_v12_final/flyback_gui_v12.py
+++ b/flyback_tool_v12_final/flyback_gui_v12.py
@@ -376,6 +376,7 @@ class App(tk.Tk):
                 ("K_ideal", lambda r: r["K"], "{:>8.3f}", 8),
                 ("Vds[V]", lambda r: r["Vds"], "{:>8.1f}", 8),
                 ("Ipk[A]", lambda r: r["Ipk"], "{:>8.2f}", 8),
+                ("ΔB[T]", lambda r: r["dB_T"], "{:>8.3f}", 8),
             ]
             for o in outs:
                 col_specs.append((f"VRRM_{o.name}[V]", lambda r, nm=o.name: r[f"VRRM_{nm}"], "{:>10.1f}", 10))
@@ -387,7 +388,7 @@ class App(tk.Tk):
                 lines.append(line)
             best = sweep["best"]
             lines.append("")
-            lines.append(f"BEST: D={best['D']:.3f}")
+            lines.append(f"BEST: D={best['D']:.3f}, ΔB={best['ref'].delta_B_T:.3f} T")
             self.k_result.delete("1.0","end"); self.k_result.insert("1.0", "\n".join(lines))
             self.sweep_cache = sweep
         except Exception as e:
@@ -443,6 +444,14 @@ class App(tk.Tk):
             lines.append(f"DCM_ok = {r['dcm_ok_main']}")
             lines.append(f"VDS ideal = {r['vds_ideal_V']:.2f} V")
             lines.append(f"VDS with clamp = {r['vds_with_overhead_V']:.2f} V")
+            lines.append(f"ΔB = {r['delta_B_T']:.3f} T")
+            vref = ini['vref_V']
+            for o in res["outputs"]:
+                name = o["name"]
+                ns = r["ns_turns"][name]
+                k_i = r["np_turns"] / ns
+                vout_real = vref / k_i - o.get("diode_drop", 0.0)
+                lines.append(f"Vout_real[{name}] = {vout_real:.2f} V")
             lines.append("")
             if r.get('diode_vrrm_required_each_V'):
                 for name, v in r['diode_vrrm_required_each_V'].items():


### PR DESCRIPTION
## Summary
- compute core flux swing (ΔB) and propagate through design results
- show ΔB and real output voltage in Results tab
- expose ΔB column and best summary in K-optimizer

## Testing
- `python -m py_compile flyback_tool_v12_final/flyback_design_v12.py flyback_tool_v12_final/flyback_gui_v12.py`
- `python flyback_tool_v12_final/flyback_design_v12.py --config flyback_tool_v12_final/design_article_example.json --json`
- `python - <<'PY'
import json
from flyback_tool_v12_final.flyback_design_v12 import normalize_cfg, FlybackInput, OutputSpec, Geometry, CoreParameters, sweep_k
cfg = json.load(open('flyback_tool_v12_final/design_article_example.json'))
cfg = normalize_cfg(cfg)
fin = FlybackInput(**cfg['input'])
outs = [OutputSpec(**o) for o in cfg['outputs']]
geom = Geometry(**cfg['geometry'])
core = CoreParameters(**cfg['core'])
res = sweep_k(fin, outs, geom, core, dmin=0.22, dmax=0.26, dstep=0.02)
crit = 'min_vds'
lines=[f"Criterion: {crit}"]
col_specs=[("D",lambda r:r['D'],"{:>6.3f}",6),("Vref[V]",lambda r:r['Vref'],"{:>8.1f}",8),("K_ideal",lambda r:r['K'],"{:>8.3f}",8),("Vds[V]",lambda r:r['Vds'],"{:>8.1f}",8),("Ipk[A]",lambda r:r['Ipk'],"{:>8.2f}",8),("ΔB[T]",lambda r:r['dB_T'],"{:>8.3f}",8)]
for o in outs: col_specs.append((f"VRRM_{o.name}[V]", lambda r,nm=o.name: r[f"VRRM_{nm}"],"{:>10.1f}",10))
col_specs.append(("Ploss[W]", lambda r: r['Ploss'],"{:>10.2f}",10))
header_line=" ".join(f"{name:>{width}}" for name,_,_,width in col_specs)
lines.append(header_line)
for row in res['grid']:
    line=" ".join(fmt.format(fn(row)) for _,fn,fmt,_ in col_specs)
    lines.append(line)
best=res['best']
lines.append("")
lines.append(f"BEST: D={best['D']:.3f}, ΔB={best['ref'].delta_B_T:.3f} T")
print("\n".join(lines))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6891cf70c2a4832f93361b78756e7205