### PR TITLE
Handle optional min load for flyback and generic results

### DIFF
--- a/converter_tool/calculations/flyback_design.py
+++ b/converter_tool/calculations/flyback_design.py
@@ -133,6 +133,7 @@ class FlybackInput:
     f_line: float = 50.0
     overload: float = 1.2
     main_output: str = ""
+    min_load_pct: float = 0.0
     force_dcm: bool = False
 
 @dataclass
@@ -494,7 +495,7 @@ def normalize_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
         try: return parse_num(x)
         except: return x
     if "input" in cfg:
-        for k in ["vin_min","vin_max","fsw","duty_max","eff","f_line","overload","cin_vrip"]:
+        for k in ["vin_min","vin_max","fsw","duty_max","eff","f_line","overload","cin_vrip","min_load_pct"]:
             if k in cfg["input"]: cfg["input"][k] = p(cfg["input"][k])
         if "force_dcm" in cfg["input"]:
             v = cfg["input"]["force_dcm"]

--- a/converter_tool/ui/main_gui.py
+++ b/converter_tool/ui/main_gui.py
@@ -802,6 +802,9 @@ class App(tk.Tk):
         messagebox.showinfo("K-optimizer", f"Применено: D(Vin_min)={Dbest:.3f}. Пересчитайте (Compute).")
     def show_results(self, res: Dict[str, Any]):
         self.res_text.delete("1.0","end")
+        if "initial" not in res:
+            self.res_text.insert("1.0", json.dumps(res, indent=2, ensure_ascii=False))
+            return
         lines = []
         ini = res["initial"]
         lines.append("=== ЭТАП 1 (без сердечника) ===")


### PR DESCRIPTION
## Summary
- accept `min_load_pct` in flyback input and parse it
- show raw results for non-flyback topologies instead of failing

## Testing
- `python -m py_compile converter_tool/calculations/flyback_design.py converter_tool/ui/main_gui.py && echo OK`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68946c2299e0832fb7152ef1901e94ef