### PR TITLE
Integrate two-switch flyback topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Current structure::
         calculations/
             base.py               # common ConverterDesign interface
              flyback_design.py         # flyback calculations
+             two_switch_flyback_design.py # two-switch flyback calculations
              forward_design.py         # forward converter
              two_switch_forward_design.py # two-switch forward calculations
              half_bridge_design.py     # placeholder for half-bridge converter
@@ -22,8 +23,8 @@ Current structure::
             core_library.json
             mosfet_library.json
 
-Flyback, forward and two-switch forward topologies are implemented. Other
-modules are stubs prepared for future expansion.
+Flyback, two-switch flyback, forward and two-switch forward topologies are
+implemented. Other modules are stubs prepared for future expansion.
 
 Run the GUI:
 

--- a/converter_tool/__init__.py
+++ b/converter_tool/__init__.py
@@ -1,5 +1,6 @@
 from .calculations import (
     FlybackDesign,
+    TwoSwitchFlybackDesign,
     ForwardDesign,
     TwoSwitchForwardDesign,
     HalfBridgeDesign,
@@ -8,6 +9,7 @@ from .calculations import (
 
 __all__ = [
     "FlybackDesign",
+    "TwoSwitchFlybackDesign",
     "ForwardDesign",
     "TwoSwitchForwardDesign",
     "HalfBridgeDesign",

--- a/converter_tool/calculations/__init__.py
+++ b/converter_tool/calculations/__init__.py
@@ -1,4 +1,5 @@
 from .flyback_design import FlybackDesign
+from .two_switch_flyback_design import TwoSwitchFlybackDesign
 from .forward_design import ForwardDesign
 from .two_switch_forward_design import TwoSwitchForwardDesign
 from .push_pull_design import PushPullDesign
@@ -7,6 +8,7 @@ from .full_bridge_design import FullBridgeDesign
 
 __all__ = [
     "FlybackDesign",
+    "TwoSwitchFlybackDesign",
     "ForwardDesign",
     "TwoSwitchForwardDesign",
     "PushPullDesign",

--- a/converter_tool/ui/main_gui.py
+++ b/converter_tool/ui/main_gui.py
@@ -20,6 +20,7 @@ if __package__ in (None, ""):
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from converter_tool.calculations.flyback_design import FlybackDesign
+from converter_tool.calculations.two_switch_flyback_design import TwoSwitchFlybackDesign
 from converter_tool.calculations.forward_design import ForwardDesign
 from converter_tool.calculations.two_switch_forward_design import TwoSwitchForwardDesign
 from converter_tool.calculations.push_pull_design import PushPullDesign
@@ -28,6 +29,7 @@ from converter_tool.calculations.full_bridge_design import FullBridgeDesign
 
 DESIGN_MAP = {
     "Flyback": FlybackDesign,
+    "2-Switch Flyback": TwoSwitchFlybackDesign,
     "Forward": ForwardDesign,
     "2-Switch Forward": TwoSwitchForwardDesign,
     "Push-Pull": PushPullDesign,
@@ -41,6 +43,7 @@ MOS_LIB_DEFAULT = os.path.join(PACKAGE_DIR, "mosfet_library.json")
 IMAGES_DIR = os.path.join(os.path.dirname(__file__), "Images")
 IMAGE_MAP = {
     "Flyback": "flyback.png",
+    "2-Switch Flyback": "Two_switch_flyback.png",
     "Forward": "Forward.png",
     "2-Switch Forward": "Two_switch_forward.png",
     "Push-Pull": "Push-Pull.png",


### PR DESCRIPTION
## Summary
- export TwoSwitchFlybackDesign in package
- add "2-Switch Flyback" option with image to GUI topology list
- document new topology in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68948ebcea4c832f9c0131a916e2ad29