### PR TITLE
Ensure GUI imports succeed when run directly

### DIFF
--- a/converter_tool/ui/main_gui.py
+++ b/converter_tool/ui/main_gui.py
@@ -16,14 +16,13 @@ from pathlib import Path
 from collections import deque
 from openai import OpenAI
 
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 from converter_tool.calculations.optocoupler_design import (
     InputParams,
     compute_optocoupler,
 )
-
-if __package__ in (None, ""):
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
-
 from converter_tool.calculations.flyback_design import FlybackDesign
 from converter_tool.calculations.two_switch_flyback_design import TwoSwitchFlybackDesign
 from converter_tool.calculations.forward_design import ForwardDesign


### PR DESCRIPTION
## Summary
- add fallback to append project root to `sys.path` in `main_gui` so the module can be executed directly

## Testing
- `python -m py_compile converter_tool/ui/main_gui.py`
- `python - <<'PY'
import runpy, traceback
try:
    runpy.run_path('converter_tool/ui/main_gui.py', run_name='__main__')
except Exception as e:
    print('raised', type(e).__name__, e)
    traceback.print_exc(limit=1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6895a0496868832f84fbe9afc709e983