### PR TITLE
Expose all optocoupler parameters in GUI

### DIFF
--- a/converter_tool/calculations/optocoupler_design.py
+++ b/converter_tool/calculations/optocoupler_design.py
@@ -456,7 +456,6 @@ class InputParams:
     i_div_uA: float = 250.0
     v_bias_zener: float = 6.2
     i_bias_mA: float = 1.0
-    vk_work: float = 2.5
     vfb: float = 2.5  # FB reference of PWM controller (Vfb comparator threshold)
     # Loop shaping parameters ----------------------------------------------
     fc: float = 1000.0
@@ -492,7 +491,7 @@ def compute_optocoupler(p: InputParams) -> Dict[str, Any]:
         boost_deg=p.boost_deg if p.comp_type != "type1" else None,
         vout=p.v_out,
         fsw_hz=p.f_sw,
-        vfb_ref=(p.vfb if hasattr(p, 'vfb') and p.vfb is not None else p.vk_work),
+        vfb_ref=p.vfb,
         params=user,
     )
 
@@ -509,7 +508,7 @@ def compute_optocoupler(p: InputParams) -> Dict[str, Any]:
     # Build a simple human‑readable report
     
     # DC sanity check: with Rpullup and target Vfb, required collector current:
-    Vfb_target = (p.vfb if hasattr(p, 'vfb') and p.vfb is not None else p.vk_work)
+    Vfb_target = p.vfb
     Ifb_req = max((p.vdd - Vfb_target) / p.r_pullup, 0.0)
     # Required LED dc current from CTR_min (worst case):
     CTRmin = p.ctr_min

--- a/converter_tool/ui/main_gui.py
+++ b/converter_tool/ui/main_gui.py
@@ -943,7 +943,7 @@ class App(tk.Tk):
         left = ttk.Frame(body, padding=6); left.pack(side="left", fill="y")
         self.opto_vars = {k: tk.StringVar() for k in [
             "v_out","f_sw","vdd","r_pullup","ctr_min","c_opto_nf","v_ref",
-            "v_f_led","vce_sat","i_div_uA","v_bias_zener","i_bias_mA","vk_work","vfb",
+            "v_f_led","vce_sat","i_div_uA","v_bias_zener","i_bias_mA","vfb",
             "fc","gc_db","boost_deg","opto_model","comp_type",
         ]}
         # defaults
@@ -960,7 +960,6 @@ class App(tk.Tk):
         self.opto_vars["i_div_uA"].set("250")
         self.opto_vars["v_bias_zener"].set("6.2")
         self.opto_vars["i_bias_mA"].set("1.0")
-        self.opto_vars["vk_work"].set("2.5")
         self.opto_vars["fc"].set("1000")
         self.opto_vars["gc_db"].set("-10")
         self.opto_vars["boost_deg"].set("60")
@@ -1003,7 +1002,7 @@ class App(tk.Tk):
         add_row(left, r, "Idiv, µA", "i_div_uA", "Ток делителя TL431; ≥150 µA"); r+=1
         add_row(left, r, "Vbias (zener), V", "v_bias_zener", "Стабилитрон узла смещения LED"); r+=1
         add_row(left, r, "Ibias TL431, mA", "i_bias_mA", "Доп. ток смещения TL431 через Rbias"); r+=1
-        add_row(left, r, "Vk work, V", "vk_work", "Рабочая точка катода TL431"); r+=1
+        add_row(left, r, "Vfb ref, V", "vfb", "Порог компаратора FB контроллера"); r+=1
         ttk.Separator(left, orient="horizontal").grid(row=r, column=0, columnspan=2, sticky="ew", pady=4); r+=1
         add_row(left, r, "fc, Hz", "fc", "Желаемая частота пересечения петли"); r+=1
         add_row(left, r, "Gc(fc), dB", "gc_db", "Модуль компенсатор+опто в fc"); r+=1
@@ -1181,7 +1180,6 @@ class App(tk.Tk):
                 i_div_uA = fget("i_div_uA", 250.0),
                 v_bias_zener = fget("v_bias_zener", 6.2),
                 i_bias_mA    = fget("i_bias_mA", 1.0),
-                vk_work = fget("vk_work", 2.5),
                 vfb    = fget("vfb", 2.5),
                 fc      = fget("fc", 1000.0),
                 gc_db   = fget("gc_db", -10.0),
@@ -1197,11 +1195,12 @@ class App(tk.Tk):
     def on_comp_type_changed(self, event=None):
         t = self.opto_vars["comp_type"].get().strip().lower()
         visible = {"v_out","f_sw","vdd","r_pullup","ctr_min","c_opto_nf",
-                   "v_ref","v_f_led","vce_sat","i_div_uA","fc","gc_db"}
+                   "v_ref","v_f_led","vce_sat","i_div_uA","i_bias_mA",
+                   "vfb","fc","gc_db"}
         if t != "type1":
             visible.add("boost_deg")
         if t in {"type2", "type3"}:
-            visible.update({"v_bias_zener","i_bias_mA","vk_work"})
+            visible.add("v_bias_zener")
         for key, frm in self.opto_field_frames.items():
             frm.grid() if key in visible else frm.grid_remove()
         img_name = {"type1":"Optocoupler_type1.png","type2":"Optocoupler_type2.png",


### PR DESCRIPTION
## Summary
- allow setting controller Vfb reference in the optocoupler tab
- show bias current and Vfb fields across compensation types
- drop deprecated Vk work parameter from GUI and design calculations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b200bd364832f92d376af369b2027