### PR TITLE
Fix indentation issues causing syntax errors

### DIFF
--- a/converter_tool/calculations/flyback_design.py
+++ b/converter_tool/calculations/flyback_design.py
@@ -327,40 +327,40 @@ def refine_with_core(fin: FlybackInput, geom: Geometry, core: CoreParameters,
             ns_turns[o.name] = max(1, int(round(np_turns / max(k_ideal, 1e-12))))
 
         k_act = np_turns / ns_turns[main_name]
-    # Compute gap/Lm with optional overrides
-    gap = None
-    lm_actual = None
-    if overrides:
-        try:
-            gap_in = overrides.get("gap_m")
-            al_in = overrides.get("al_nH_per_turn2")
-        except Exception:
-            gap_in = None; al_in = None
-        if gap_in:
+        # Compute gap/Lm with optional overrides
+        gap = None
+        lm_actual = None
+        if overrides:
             try:
-                gap = float(gap_in)
-                lm_actual = MU0 * (np_turns**2) * Ae / max(gap, 1e-18)
+                gap_in = overrides.get("gap_m")
+                al_in = overrides.get("al_nH_per_turn2")
             except Exception:
-                gap = None
-        if (lm_actual is None) and al_in:
-            try:
-                AL = float(al_in) * 1e-9  # H/turn^2
-                lm_actual = AL * (np_turns**2)
-                gap = MU0 * (np_turns**2) * Ae / max(lm_actual, 1e-18)
-            except Exception:
-                lm_actual = None
-    if (gap is None) or (lm_actual is None):
-        gap = MU0 * (np_turns**2) * Ae / max(ini.lm_target_H, 1e-18)
-        lm_actual = MU0 * (np_turns**2) * Ae / gap
-        ipk = (fin.vin_min * ini.d_vin_min) / (lm_actual * fin.fsw)
-        irms_pri = ipk * (ini.d_vin_min/3.0) ** 0.5
-        lsec_main = lm_actual * (ns_turns[main_name]/np_turns)**2
-        ipk_sec_main = ipk * k_act
-        toff = lsec_main * ipk_sec_main / (main.v + main.diode_drop)
-        dcm_ok = toff <= (1.0 - ini.d_vin_min) * period + 1e-15
-        if not force_dcm or dcm_ok or np_turns>1000:
-            break
-        np_turns += 1
+                gap_in = None; al_in = None
+            if gap_in:
+                try:
+                    gap = float(gap_in)
+                    lm_actual = MU0 * (np_turns**2) * Ae / max(gap, 1e-18)
+                except Exception:
+                    gap = None
+            if (lm_actual is None) and al_in:
+                try:
+                    AL = float(al_in) * 1e-9  # H/turn^2
+                    lm_actual = AL * (np_turns**2)
+                    gap = MU0 * (np_turns**2) * Ae / max(lm_actual, 1e-18)
+                except Exception:
+                    lm_actual = None
+        if (gap is None) or (lm_actual is None):
+            gap = MU0 * (np_turns**2) * Ae / max(ini.lm_target_H, 1e-18)
+            lm_actual = MU0 * (np_turns**2) * Ae / gap
+            ipk = (fin.vin_min * ini.d_vin_min) / (lm_actual * fin.fsw)
+            irms_pri = ipk * (ini.d_vin_min/3.0) ** 0.5
+            lsec_main = lm_actual * (ns_turns[main_name]/np_turns)**2
+            ipk_sec_main = ipk * k_act
+            toff = lsec_main * ipk_sec_main / (main.v + main.diode_drop)
+            dcm_ok = toff <= (1.0 - ini.d_vin_min) * period + 1e-15
+            if not force_dcm or dcm_ok or np_turns>1000:
+                break
+            np_turns += 1
 
     # Flux swing (ΔB)
     dB = (fin.vin_max * ini.d_vin_min) / (np_turns * Ae * fin.fsw)

--- a/converter_tool/ui/main_gui.py
+++ b/converter_tool/ui/main_gui.py
@@ -942,43 +942,43 @@ class App(tk.Tk):
         result_frame.columnconfigure(0, weight=1)
         result_frame.rowconfigure(0, weight=1)
     
-class TransformerEditDialog(tk.Toplevel):
-    def __init__(self, master, current=None):
-        super().__init__(master)
-        self.title("Edit transformer")
-        self.resizable(False, False)
-        self.result = None
-        cur = current or {}
-        frm = ttk.Frame(self, padding=10); frm.pack(fill="both", expand=True)
-        # Fields: Np, gap (mm), AL (nH/turn^2)
-        self.vars = {
-            "np_turns": tk.StringVar(value=str(cur.get("np_turns","") or "")),
-            "gap_mm": tk.StringVar(value=str(cur.get("gap_mm","") or "")),
-            "al_nH_per_turn2": tk.StringVar(value=str(cur.get("al_nH_per_turn2","") or "")),
-        }
-        row=0
-        for lbl,key in [("Primary turns Np","np_turns"),("Gap, mm","gap_mm"),("AL, nH/turn²","al_nH_per_turn2")]:
-            ttk.Label(frm, text=lbl).grid(row=row, column=0, sticky="e", pady=4, padx=6)
-            ttk.Entry(frm, textvariable=self.vars[key], width=18).grid(row=row, column=1, sticky="w")
-            row+=1
-        ttk.Label(frm, text="Заполните один или несколько параметров; пустые поля не изменяют расчет.").grid(row=row, column=0, columnspan=2, pady=(8,6))
-        btns = ttk.Frame(frm); btns.grid(row=row+1, column=0, columnspan=2, pady=6)
-        ttk.Button(btns, text="OK", command=self.ok).pack(side="left", padx=6)
-        ttk.Button(btns, text="Cancel", command=self.cancel).pack(side="left", padx=6)
+    class TransformerEditDialog(tk.Toplevel):
+        def __init__(self, master, current=None):
+            super().__init__(master)
+            self.title("Edit transformer")
+            self.resizable(False, False)
+            self.result = None
+            cur = current or {}
+            frm = ttk.Frame(self, padding=10); frm.pack(fill="both", expand=True)
+            # Fields: Np, gap (mm), AL (nH/turn^2)
+            self.vars = {
+                "np_turns": tk.StringVar(value=str(cur.get("np_turns","") or "")),
+                "gap_mm": tk.StringVar(value=str(cur.get("gap_mm","") or "")),
+                "al_nH_per_turn2": tk.StringVar(value=str(cur.get("al_nH_per_turn2","") or "")),
+            }
+            row=0
+            for lbl,key in [("Primary turns Np","np_turns"),("Gap, mm","gap_mm"),("AL, nH/turn²","al_nH_per_turn2")]:
+                ttk.Label(frm, text=lbl).grid(row=row, column=0, sticky="e", pady=4, padx=6)
+                ttk.Entry(frm, textvariable=self.vars[key], width=18).grid(row=row, column=1, sticky="w")
+                row+=1
+            ttk.Label(frm, text="Заполните один или несколько параметров; пустые поля не изменяют расчет.").grid(row=row, column=0, columnspan=2, pady=(8,6))
+            btns = ttk.Frame(frm); btns.grid(row=row+1, column=0, columnspan=2, pady=6)
+            ttk.Button(btns, text="OK", command=self.ok).pack(side="left", padx=6)
+            ttk.Button(btns, text="Cancel", command=self.cancel).pack(side="left", padx=6)
+    
+        def ok(self):
+            out = {}
+            for k,v in self.vars.items():
+                s = v.get().strip()
+                if s != "":
+                    out[k] = s
+            self.result = out or None
+            self.destroy()
+        def cancel(self):
+            self.result=None
+            self.destroy()
 
-    def ok(self):
-        out = {}
-        for k,v in self.vars.items():
-            s = v.get().strip()
-            if s != "":
-                out[k] = s
-        self.result = out or None
-        self.destroy()
-    def cancel(self):
-        self.result=None
-        self.destroy()
-
-def build_results_tab(self):
+    def build_results_tab(self):
         tab = ttk.Frame(self.nb); self.nb.add(tab, text="Results")
         top = ttk.Frame(tab, padding=6); top.pack(fill="x")
         ttk.Button(top, text="Compute", command=self.compute).pack(side="left", padx=4)


### PR DESCRIPTION
## Summary
- fix indentation for TransformerEditDialog and results/optocoupler methods in main_gui
- correct flyback core gap loop indentation to keep break inside while

## Testing
- `python -m py_compile converter_tool/ui/main_gui.py converter_tool/calculations/flyback_design.py`


------
https://chatgpt.com/codex/tasks/task_e_68a32466c780832f81f9bcaf933aa80d